### PR TITLE
Improve cms-skeleton by using the symfony/website-skeleton as the base composer and add our packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "kunstmaan/cms-skeleton",
     "type": "project",
-    "description": "A skeleton to start your new KunstmaanCMS website",
+    "description": "A skeleton to start your new Kunstmaan CMS website",
     "keywords": ["cms"],
     "homepage": "https://bundles.kunstmaan.be",
     "license": "MIT",
@@ -15,48 +15,51 @@
             "homepage": "https://github.com/Kunstmaan/KunstmaanBundlesCMS/graphs/contributors"
         }
     ],
-    "minimum-stability": "dev",
     "require": {
-        "php": "^7.1",
+        "php": "^7.1.3",
         "ext-ctype": "*",
         "ext-iconv": "*",
-        "kunstmaan/cms-pack": "*",
-        "kunstmaan/cache-bundle": "*",
-        "kunstmaan/config-bundle": "*",
-        "kunstmaan/dashboard-bundle": "*",
-        "kunstmaan/menu-bundle": "*",
-        "kunstmaan/node-search-bundle": "*",
-        "kunstmaan/redirect-bundle": "*",
-        "kunstmaan/search-bundle": "*",
+        "kunstmaan/cms-pack": "*@dev",
+        "kunstmaan/cache-bundle": "^5.2",
+        "kunstmaan/config-bundle": "^5.2",
+        "kunstmaan/dashboard-bundle": "^5.2",
+        "kunstmaan/menu-bundle": "^5.2",
+        "kunstmaan/node-search-bundle": "^5.2",
+        "kunstmaan/redirect-bundle": "^5.2",
+        "kunstmaan/search-bundle": "^5.2",
         "doctrine/doctrine-migrations-bundle": "^1.3",
         "egulias/email-validator": "^1.2.8|^2.0",
         "ekino/newrelic-bundle": "^1.4",
-        "friendsofsymfony/http-cache-bundle": "~1.3.6",
         "sentry/sentry": "^1.4",
-        "symfony/dotenv": "*",
-        "symfony/flex": "^1.1"
+        "sensio/framework-extra-bundle": "^5.1",
+        "symfony/asset": "^4.2",
+        "symfony/console": "^4.2",
+        "symfony/dotenv": "^4.2",
+        "symfony/expression-language": "^4.2",
+        "symfony/flex": "^1.1",
+        "symfony/form": "^4.2",
+        "symfony/framework-bundle": "^4.2",
+        "symfony/monolog-bundle": "^3.1",
+        "symfony/orm-pack": "*",
+        "symfony/process": "^4.2",
+        "symfony/security-bundle": "^4.2",
+        "symfony/serializer-pack": "*",
+        "symfony/swiftmailer-bundle": "^3.1",
+        "symfony/translation": "^4.2",
+        "symfony/twig-bundle": "^4.2",
+        "symfony/validator": "^4.2",
+        "symfony/web-link": "^4.2",
+        "symfony/yaml": "^4.2"
     },
     "require-dev": {
         "kunstmaan/behat-bundle": "^5.2",
         "kunstmaan/generator-bundle": "^5.2",
         "kunstmaan/fixtures-bundle": "^5.2",
-        "behat/behat": "3.1.0rc1",
-        "behat/mink": "dev-master",
-        "behat/mink-browserkit-driver": "dev-master",
-        "behat/mink-extension": "~2.0",
-        "behat/mink-goutte-driver": "dev-master",
-        "behat/mink-selenium2-driver": "dev-master",
-        "behat/mink-sahi-driver": "dev-master",
-        "behat/symfony2-extension": "~2.1.1",
-        "codeception/codeception": "^2.4",
-        "fzaninotto/faker": "~1.6",
-        "lakion/mink-debug-extension": "^1.2",
-        "matthiasnoback/symfony-config-test": "2.2.0",
-        "matthiasnoback/symfony-dependency-injection-test": "1.2.0",
-        "phpunit/phpunit": "^5.7",
         "symfony/debug-pack": "*",
-        "symfony/phpunit-bridge": "~3.0",
-        "symfony/profiler-pack": "*"
+        "symfony/maker-bundle": "^1.0",
+        "symfony/profiler-pack": "*",
+        "symfony/test-pack": "*",
+        "symfony/web-server-bundle": "^4.2"
     },
     "suggest": {
         "phpro/grumphp": "A PHP code-quality tool",
@@ -79,11 +82,16 @@
             "App\\Tests\\": "tests/"
         }
     },
+    "replace": {
+        "paragonie/random_compat": "2.*",
+        "symfony/polyfill-ctype": "*",
+        "symfony/polyfill-iconv": "*",
+        "symfony/polyfill-php71": "*",
+        "symfony/polyfill-php70": "*",
+        "symfony/polyfill-php56": "*"
+    },
     "scripts": {
-        "auto-scripts": {
-            "cache:clear": "symfony-cmd",
-            "assets:install %PUBLIC_DIR%": "symfony-cmd"
-        },
+        "auto-scripts": [],
         "post-install-cmd": [
             "@auto-scripts"
         ],
@@ -97,7 +105,8 @@
     },
     "extra": {
         "symfony": {
-            "allow-contrib": true
+            "allow-contrib": false,
+            "require": "4.2.*"
         }
     }
 }


### PR DESCRIPTION
Require the same packages as the symfony/website-skeleton + our cms packages (and required deprendencies). 

I've removed the behat dependencies as we don't provide behat out-of-the-box and the users should just do a behat setup for their envorinment. They can just execute`composer req behat/symfony2-extension` to get the official recipe with correct default config