### PR TITLE
Temporary remove cache bundle from the skeleton

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "ext-ctype": "*",
         "ext-iconv": "*",
         "kunstmaan/cms-pack": "*@dev",
-        "kunstmaan/cache-bundle": "^5.2",
         "kunstmaan/config-bundle": "^5.2",
         "kunstmaan/dashboard-bundle": "^5.2",
         "kunstmaan/menu-bundle": "^5.2",


### PR DESCRIPTION
Let's ship the skeleton without the cache bundle for now and add it again when we tested and fixed this bundle 